### PR TITLE
Add simultaneous audio playback support

### DIFF
--- a/lib/services/audio_player_service.dart
+++ b/lib/services/audio_player_service.dart
@@ -1,19 +1,19 @@
 import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
-import 'package:uuid/uuid.dart';
 import '../models/sound.dart';
 import 'package:flutter/foundation.dart';
 
 class AudioPlayerService extends ChangeNotifier {
   final Map<String, AudioPlayer> _activePlayers = {};
-  final AudioPlayer _backgroundPlayer = AudioPlayer();
-  final Uuid _uuid = const Uuid();
 
   Future<void> playSound(Sound sound) async {
-    final player = AudioPlayer();
-    final playerId = _uuid.v4();
+    // Stop the sound first if it's already playing to avoid duplicates
+    if (_activePlayers.containsKey(sound.id)) {
+      await stopSound(sound.id);
+    }
 
-    _activePlayers[playerId] = player;
+    final player = AudioPlayer();
+    _activePlayers[sound.id] = player;
 
     try {
       await player.setAudioSource(
@@ -34,24 +34,22 @@ class AudioPlayerService extends ChangeNotifier {
         if (!sound.loop) {
           player.playerStateStream.listen((state) {
             if (state.processingState == ProcessingState.completed) {
-              _disposePlayer(playerId);
+              _disposePlayer(sound.id);
             }
           });
         }
       });
     } catch (e) {
       print('Error playing sound: $e');
-      _disposePlayer(playerId);
+      _disposePlayer(sound.id);
     }
   }
 
   Future<void> stopSound(String soundId) async {
-    final playersToStop =
-        _activePlayers.entries.where((entry) => entry.key == soundId).toList();
-
-    for (var entry in playersToStop) {
-      await entry.value.stop();
-      _disposePlayer(entry.key);
+    final player = _activePlayers[soundId];
+    if (player != null) {
+      await player.stop();
+      _disposePlayer(soundId);
     }
   }
 
@@ -79,6 +77,5 @@ class AudioPlayerService extends ChangeNotifier {
 
   void dispose() {
     stopAllSounds();
-    _backgroundPlayer.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- store active players by sound ID instead of random Uuid
- dispose players and stop existing sound before starting new
- remove unused background player and uuid

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b84565a488323a1ce244ed5a3640c