### PR TITLE
Fix lints and update tests

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -107,15 +107,6 @@ class _HomeScreenState extends State<HomeScreen> {
     ],
   };
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/services/audio_player_service.dart
+++ b/lib/services/audio_player_service.dart
@@ -57,7 +57,7 @@ class AudioPlayerService extends ChangeNotifier {
 
       _fadeVolume(player, 0.0, sound.volume, const Duration(seconds: 1));
     } catch (e) {
-      print('Error playing sound: $e');
+      debugPrint('Error playing sound: $e');
       _disposePlayer(sound.id);
     }
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,13 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:soundforge/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App loads home screen', (WidgetTester tester) async {
+    await tester.pumpWidget(const SoundForgeApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('SoundForge'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- remove empty lifecycle overrides in `HomeScreen`
- replace `print` with `debugPrint` in audio service
- simplify widget test to load `SoundForgeApp`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b878509b8832392c85637ca65512a