### PR TITLE
Fix unbounded height on sound grid

### DIFF
--- a/lib/widgets/sound_grid.dart
+++ b/lib/widgets/sound_grid.dart
@@ -15,6 +15,8 @@ class SoundGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     return GridView.builder(
       padding: const EdgeInsets.all(16),
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
         childAspectRatio: 1.0,


### PR DESCRIPTION
## Summary
- prevent `SoundGrid` from taking infinite height by setting `shrinkWrap` and disabling its internal scrolling

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b89414ff48323b3ce8208835695ab